### PR TITLE
Replace rand() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Other things that can / should be improved in the code (volunteers welcome!):
 - There are some data races between the editor and processor. For example, VU meter RMS readings should be atomic, and ideally be independent of the block size.
 - Remove most of the compiler warnings. (I set the warning level high on purpose.)
 - Replace the Biquads with TPT / SVF filters.
-- Don't use `rand()` and `srand()`. Replace with `juce::Random`.
+- [Needs review] ~~Don't use `rand()` and `srand()`. Replace with `juce::Random`.~~
 - Parameter smoothing.
 - When you put the plug-in in bypass mode, change the Age or Shame controls, and disable bypass, there can be a glitch because old filter state etc no longer makes sense.
 
@@ -177,6 +177,7 @@ Maybe:
 - When you drag to apply flanging, I would expect a mouse up to reset the flanging depth, since the animation does return to normal speed.
 - Skew the flange depth so that shorter delays are easier to dial in. (For example by doing `targetDepth = depth * depth * 1000.0f`.)
 - Oversampling. The saturation stage can easily add aliases.
+- [Needs to include AAX] ~~Use CMake instead of Projucer~~.
 
 ## Credits & license
 

--- a/Source/AudioProcessing/EnvelopeDips.h
+++ b/Source/AudioProcessing/EnvelopeDips.h
@@ -10,9 +10,10 @@ class EnvelopeDips
 {
 public:
     EnvelopeDips() : incr(0.0f), domain(44100.0f), dynamicExtremity(0.0f),
-                     numPointRandomness(0.0f), numPoints(5)
+                     numPointRandomness(0.0f), numPoints(5),
+                     rng(juce::Random::getSystemRandom())
     {
-        srand(time(nullptr));
+        rng.setSeed(time(nullptr));
 
         calculateDipPoints();
 
@@ -91,7 +92,8 @@ public:
         for (int i = 0; i < numRandPoints; i++) {
             float xInit = float(i + 1) / float(numRandPoints + 1);
             float xDeviation = random() * partitionSize * 0.4f;
-            if (rand() % 2) {
+            
+            if (rng.nextBool()) {
                 xDeviation = -xDeviation;
             }
             points.add({ xInit + xDeviation, 1.0f - dynamicExtremity*random() });
@@ -103,7 +105,7 @@ public:
 private:
     float random() const noexcept
     {
-        return float(rand() % 1000) / 1000.0f;
+        return rng.nextFloat();
     }
 
     float incr;
@@ -112,5 +114,7 @@ private:
     float numPointRandomness;
     int numPoints;
 
+    juce::Random &rng;
+    
     juce::Array<juce::Point<float>> points;
 };

--- a/Source/AudioProcessing/Granulate.cpp
+++ b/Source/AudioProcessing/Granulate.cpp
@@ -18,7 +18,7 @@
 #include "Granulate.h"
 #include <cmath>
 
-Granulate::Granulate(unsigned int nVoices, const char* data, int size)
+Granulate::Granulate(unsigned int nVoices, const char* data, int size) : rng(juce::Random::getSystemRandom())
 {
     setGrainParameters();  // use default values
     setRandomFactor();
@@ -129,7 +129,7 @@ void Granulate::calculateGrain(Granulate::Grain& grain)
 
     // Calculate duration and envelope parameters.
     float seconds = gDuration_ * 0.001f;
-    seconds += seconds * gRandomFactor_ * noise.tick();
+    seconds += seconds * gRandomFactor_ * (rng.nextFloat() * 2.0f - 1.0f);
     unsigned long count = (unsigned long)(seconds * SAMPLE_RATE);
     grain.attackCount = (unsigned int)(gRampPercent_ * 0.005f * count);
     grain.decayCount = grain.attackCount;
@@ -146,7 +146,7 @@ void Granulate::calculateGrain(Granulate::Grain& grain)
 
     // Calculate delay parameter.
     seconds = gDelay_ * 0.001f;
-    seconds += seconds * gRandomFactor_ * noise.tick();
+    seconds += seconds * gRandomFactor_ * (rng.nextFloat() * 2.0f - 1.0f);
     count = (unsigned long)(seconds * SAMPLE_RATE);
     grain.delayCount = count;
 
@@ -155,11 +155,11 @@ void Granulate::calculateGrain(Granulate::Grain& grain)
 
     // Calculate offset parameter.
     seconds = gOffset_ * 0.001f;
-    seconds += seconds * gRandomFactor_ * std::abs(noise.tick());
+    seconds += seconds * gRandomFactor_ * rng.nextFloat();
     int offset = int(seconds * SAMPLE_RATE);
 
     // Add some randomization to the pointer start position.
-    seconds = gDuration_ * 0.001f * gRandomFactor_ * noise.tick();
+    seconds = gDuration_ * 0.001f * gRandomFactor_ * (rng.nextFloat() * 2.0f - 1.0f);
     offset += int(seconds * SAMPLE_RATE);
     grain.pointer += offset;
     while (grain.pointer >= audioData->getNumSamples()) {

--- a/Source/AudioProcessing/Granulate.h
+++ b/Source/AudioProcessing/Granulate.h
@@ -132,4 +132,6 @@ protected:
     int gOffset_;
     float gRandomFactor_;
     float gain_;
+
+    juce::Random &rng;
 };

--- a/Source/AudioProcessing/HurricaneSandy.h
+++ b/Source/AudioProcessing/HurricaneSandy.h
@@ -11,7 +11,7 @@
 class HurricaneSandy
 {
 public:
-    HurricaneSandy() : grainImpact(0.0f), ampFluctuationImpact(0.0f)
+    HurricaneSandy() : grainImpact(0.0f), ampFluctuationImpact(0.0f), rng(juce::Random::getSystemRandom())
     {
         // Used for general amplitude fluctuation
         dips.setDomainMS(1000.0f);  // milliseconds
@@ -81,7 +81,7 @@ public:
                 }
 
                 // Mix signal with periodic noise burst.
-                float noiseBurst = signalEnvValue * samples[i] + 0.05f * noiseBurstEnvValue * whiteNoise.tick();
+                float noiseBurst = signalEnvValue * samples[i] + 0.05f * noiseBurstEnvValue * (rng.nextFloat() * 2.0f - 1.0f);
                 samples[i] = (1.0f - noiseBurstImpact)*samples[i] + noiseBurstImpact*noiseBurst;
 
                 // Modulate the amplitude by the granular amplitude
@@ -142,4 +142,6 @@ private:
     float lowFreqGrainNoiseLevel;
     float ampFluctuationImpact;
     float noiseBurstImpact;
+
+    juce::Random &rng;
 };

--- a/Source/AudioProcessing/Shame.h
+++ b/Source/AudioProcessing/Shame.h
@@ -7,7 +7,8 @@
 class Shame
 {
 public:
-    Shame(int numChannels)
+    Shame(int numChannels) : 
+    rng(juce::Random::getSystemRandom())
     {
         depth = 0.5f;
         rate = 2.0f;
@@ -175,7 +176,7 @@ private:
 
         // Reached the end of the wavetable? Choose a new random rate fluctuation.
         if (curPos_wTable >= BUFFER_SIZE) {
-            float random = float(rand() % 2000)/1000.0f - 1.0f;  // -1 ... +1
+            float random = rng.nextFloat() * 2.0f - 1.0f;  // -1 ... +1
             rateFluctuation = random * rate * randPeriodicity;
             curPos_wTable -= BUFFER_SIZE;
         }
@@ -200,6 +201,8 @@ private:
 
     // Several wavetables that each contain a single cycle waveform
     juce::OwnedArray<juce::AudioBuffer<float>> waveTableBuffers;
+
+    juce::Random &rng;
 
     float waveformIndx;      // which wavetable to use (can be fractional)
     float curPos_wTable;     // read position in the wavetable (fractional)


### PR DESCRIPTION
Replace rand() calls with juce::Random ones

Uses references to system juce::Random object instance