### PR TITLE
Fix link buttons not appearing in collapsed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The following changes were made in this repo:
 
 Bugs I found (or introduced hehe):
 
-- The Link buttons under the input/output knobs disappear when the reels are hidden.
+- [FIXED] ~~The Link buttons under the input/output knobs disappear when the reels are hidden.~~
 - Sometimes there is an extremely loud glitch. Not sure yet what causes this, maybe some uninitialized memory. Hard to reproduce.
 - The hacky way I've implemented the Link Input/Output mode may be problematic. Sometimes this gives an assertion on `beginGesture` being called twice. Not a massive problem but not great either.
 - When restoring state, the Shame knob's cross is in the right position but the colored track isn't shown.

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -207,6 +207,10 @@ void KissOfShameAudioProcessorEditor::setReelMode(bool showReels)
     vuMeterR.setTopLeftPosition(vuMeterR.getX(), vuMeterR.getY() + adjustment);
     shameKnobImage.setTopLeftPosition(shameKnobImage.getX(), shameKnobImage.getY() + adjustment);
 
+    // Link Buttons
+    linkIOButtonL.setTopLeftPosition(linkIOButtonL.getX(), linkIOButtonL.getY() + adjustment);
+    linkIOButtonR.setTopLeftPosition(linkIOButtonR.getX(), linkIOButtonR.getY() + adjustment);
+
     if (showReels) {
         faceImage.setAnimationImage(BinaryData::FaceWithReels_png, BinaryData::FaceWithReels_pngSize);
         faceImage.setDimensions(0, 0, 960, 703);


### PR DESCRIPTION
Link buttons now appear in collapsed mode

![image](https://github.com/hollance/TheKissOfShame/assets/36148073/eec79f8e-47bd-43d5-86db-59bb9d5ab0f5)